### PR TITLE
Changed "An Element" ==> "Any Element" for universal selector *

### DIFF
--- a/src/explain/spec.js
+++ b/src/explain/spec.js
@@ -16,7 +16,7 @@ describe('Basics', () => {
 describe('Smoke', () => {
   const tests = {
     // Elements
-    '*': 'All elements',
+    '*': 'Any element',
     p: 'A ‘<p>’ element',
     a: 'An ‘<a>’ element',
 

--- a/src/explain/spec.js
+++ b/src/explain/spec.js
@@ -16,7 +16,7 @@ describe('Basics', () => {
 describe('Smoke', () => {
   const tests = {
     // Elements
-    '*': 'An element',
+    '*': 'All elements',
     p: 'A ‘<p>’ element',
     a: 'An ‘<a>’ element',
 

--- a/src/getSelectorSubject/index.js
+++ b/src/getSelectorSubject/index.js
@@ -10,6 +10,7 @@ import { highlight } from '../utils'
  */
 export default component => {
   const { id, tagName } = component
+ 
   const tag = tagName && tagName !== '*' ? highlight(`<${tagName}>`) : ''
   const content = [tag, 'element'].filter(Boolean).join(' ')
   const article =
@@ -18,6 +19,8 @@ export default component => {
       : /^[aeiouy]/.test(content.replace('‘<', ''))
       ? 'an'
       : 'a'
-
+  if (tagName === '*') {
+    return `all ${content}s`;
+  }
   return parsePseudoElement(component) + article + ' ' + content
 }

--- a/src/getSelectorSubject/index.js
+++ b/src/getSelectorSubject/index.js
@@ -20,7 +20,7 @@ export default component => {
       ? 'an'
       : 'a'
   if (tagName === '*') {
-    return `all ${content}s`;
+    return `any ${content}`;
   }
   return parsePseudoElement(component) + article + ' ' + content
 }

--- a/src/getSelectorSubject/spec.js
+++ b/src/getSelectorSubject/spec.js
@@ -2,7 +2,7 @@ import getSelectorSubject from './'
 
 describe('The `getSelectorSubject` function', () => {
   it('should handle the wildcard selector', () => {
-    expect(getSelectorSubject({ tagName: '*' })).toBe('an element')
+    expect(getSelectorSubject({ tagName: '*' })).toBe('all elements')
   })
 
   it('should handle element selectors', () => {

--- a/src/getSelectorSubject/spec.js
+++ b/src/getSelectorSubject/spec.js
@@ -2,7 +2,7 @@ import getSelectorSubject from './'
 
 describe('The `getSelectorSubject` function', () => {
   it('should handle the wildcard selector', () => {
-    expect(getSelectorSubject({ tagName: '*' })).toBe('all elements')
+    expect(getSelectorSubject({ tagName: '*' })).toBe('any element')
   })
 
   it('should handle element selectors', () => {
@@ -13,7 +13,7 @@ describe('The `getSelectorSubject` function', () => {
     expect(getSelectorSubject({ tagName: 'html' })).toBe('the ‘<html>’ element')
     expect(getSelectorSubject({ tagName: 'body' })).toBe('the ‘<body>’ element')
     expect(getSelectorSubject({ tagName: 'head' })).toBe('the ‘<head>’ element')
-  })
+  })   
 
   it('should handle id selectors', () => {
     expect(getSelectorSubject({ id: 'foo' })).toBe('the element')


### PR DESCRIPTION
## There was wrong explanation of  universal selector (*) it must be All elements but it returns An element   
@KittyGiraudel @Kilian @SelenIT 
please have a look and merge
Thank you 
wrong ⬇️
![wrong term ](https://github.com/KittyGiraudel/selectors-explained/assets/71798304/79af97f4-065d-4ad9-b7a7-c1a61943ae1d)
Correct ⬇️
 
![right-term](https://github.com/KittyGiraudel/selectors-explained/assets/71798304/7ee07bf5-c38c-47b6-8a70-dff6d0a31c70)
